### PR TITLE
fix historical queries taking client as global variable.

### DIFF
--- a/pkg/runner/run.go
+++ b/pkg/runner/run.go
@@ -108,7 +108,7 @@ func Run(cfg *config.Config, home string) error {
 
 	for _, client := range clients {
 		if client.Config.ChainID != cfg.DefaultChain {
-			go func(c *lensclient.ChainClient, logger log.Logger) {
+			go func(c *lensclient.ChainClient, client *lensclient.ChainClient, logger log.Logger) {
 			CNT:
 				for {
 					req := &qstypes.QueryRequestsRequest{
@@ -139,7 +139,7 @@ func Run(cfg *config.Config, home string) error {
 					time.Sleep(30 * time.Second)
 
 				}
-			}(defaultClient, log.With(logger, "chain", defaultClient.Config.ChainID, "src_chain", client.Config.ChainID))
+			}(defaultClient, client, log.With(logger, "chain", defaultClient.Config.ChainID, "src_chain", client.Config.ChainID))
 			wg.Add(1)
 		}
 	}


### PR DESCRIPTION
the historical requests go func takes `client` as global variable, hence doesn't work as expected.
the for loop on top updates the client variable, causing the historical queries to only run for last(index) of the clients